### PR TITLE
Publish NIME 2024 Utrecht and Oslo trip post

### DIFF
--- a/_posts/2024-09-10-nime-2024-utrecht-oslo.md
+++ b/_posts/2024-09-10-nime-2024-utrecht-oslo.md
@@ -1,0 +1,102 @@
+---
+layout: post
+title: NIME 2024 in Utrecht and Oslo
+date: 2024-09-10
+category: posts
+tags:
+- research
+- conference
+- travel
+- photography
+- nime
+description: Travelling to Utrecht for NIME 2024 to run a workshop on embedded AI, watching lab members Yichen Wang and Sandy Ma perform Unspoken, announcing NIME2025 in Canberra, and visiting colleagues at the University of Oslo.
+image: /assets/blog/2024/2024-NIME-trip-01.jpg
+---
+
+In September 2024 I travelled to Utrecht, Netherlands for NIME 2024, later stopping by Oslo to visit colleagues at the University of Oslo.
+
+The trip to NIME involved presenting a workshop and seeing lab members Yichen Wang and Sandy Ma presenting their musical work at the conference.
+
+![NIME 2024 in Utrecht]({% link assets/blog/2024/2024-NIME-trip-01.jpg %})
+
+## Building NIMEs with Embedded AI Workshop
+
+My workshop was called [Building NIMEs with Embedded AI](https://smcclab.au/nime-embedded-ai/) and was organised in collaboration with Teresa Pelinski from Queen Mary University of London.
+
+Teresa's research involves running AI models on the [Bela](https://bela.io), and my work involves running AI models on the Raspberry Pi — a difference that I frame as a creative battle of ideas. Together we were catering to whatever linux single-board computing platform NIMErs were interested in!
+
+We split the day into two long sessions with the goal of getting everybody to get a basic AI model working on our respective systems. The workshop was (as expected) very busy with interest from NIMErs new and old.
+
+![Workshop AI system]({% link assets/blog/2024/2024-NIME-trip-02-workshop-AI-system.jpg %})
+
+In preparation for my [half of the workshop](https://smcclab.au/nime-embedded-ai/rpi/), I had built some _ultraportable_ AI NIME development kits. Each kit included:
+
+- a Raspberry Pi Zero 2 W: the cheapest way to build an AI-powered NIME
+- a 16GB SD card
+- an OTG USB dongle to get a USB socket out of the Pi Zero
+- 2x USB A to micro B cables, one for power and one for...
+- a BBC Microbit v2
+
+The Microbits were a bit of an unusual addition to the system. I wanted a _very_ lightweight way to connect the Pi Zeros to something with sensor input and sound output. I had last used Microbits for teaching _COMP2300_ and Sound and Music Computing so I had lots around my lab. The Microbits have an on board speaker (sound output check) and an accelerometer (sensor input check) and the little LED matrix display (more feedback check). Programming them in their native Python environment, I could get _sounds_, not necessarily anything interesting or very fun, but a noisy kind of sound effect related to the accelerometer. I frame these as the world's worst NIME and I may not be too far wrong. In any case, they worked for demonstration purposes connected to the IMPSY Pi systems.
+
+![Workshop session]({% link assets/blog/2024/2024-NIME-trip-03-workshop.jpg %})
+
+![Workshop participants]({% link assets/blog/2024/2024-NIME-trip-04-workshop.jpg %})
+
+## Performances and Demos
+
+The conference featured a rich program of performances and demos alongside the paper and workshop sessions.
+
+![NIME 2024]({% link assets/blog/2024/2024-NIME-trip-05.jpg %})
+
+![NIME 2024]({% link assets/blog/2024/2024-NIME-trip-06.jpg %})
+
+![NIME 2024]({% link assets/blog/2024/2024-NIME-trip-07.jpg %})
+
+![NIME 2024]({% link assets/blog/2024/2024-NIME-trip-08.jpg %})
+
+![NIME 2024]({% link assets/blog/2024/2024-NIME-trip-09.jpg %})
+
+![Intelligent S1]({% link assets/blog/2024/2024-NIME-trip-10-intelligent-S1.jpg %})
+
+![Touching Wires performance]({% link assets/blog/2024/2024-NIME-trip-11-touching-wires.jpg %})
+
+A highlight of this NIME was seeing my SMCClab students Yichen Wang and Sandy Ma performing their new work _Unspoken_ as part of the conference.
+
+Getting music works into NIME is no easy task. Space (and time) is tighter in the music program than for papers so fewer works are programmed and the competition can be really tough. I was so proud to contribute as a supervisor to this work, and happy to watch from the audience this time!
+
+Yichen describes Unspoken as: "A mixed reality duet performance that explores the aesthetic possibilities of augmented reality technology as a medium for collaborative musical expression. Musicians with their tangible musical systems, communicate gestural and spatial musical intentions through a shared AR interface."
+
+This work combines my lab's research directions of AR performance and collaboration to create an original work that couldn't exist without the technologies involved. The staging of Unspoken in Utrecht was just stunning — well done Yichen and Sandy!
+
+![Unspoken performance]({% link assets/blog/2024/2024-NIME-trip-12-unspoken.jpg %})
+
+![Unspoken performance]({% link assets/blog/2024/2024-NIME-trip-13-unspoken.jpg %})
+
+![NIME 2024]({% link assets/blog/2024/2024-NIME-trip-14.jpg %})
+
+## Announcing NIME2025
+
+The end of NIME is a traditional time to announce _the next_ NIME to the community. This was a big moment for me as we are hosting NIME2025 in Canberra! I introduced the rough plans for NIME at ANU, including our plan for hybrid and remote options for attendance, and played our teaser video publicly for the first time.
+
+## University of Oslo Meetings
+
+Next stop was Oslo to catch up with colleagues at the University of Oslo and around town. This was a chance to catch up with Dr Benedikte Wallace to hear what has been happening since completing her PhD and starting as a postdoc, and to connect with the rest of my network at ROBIN and RITMO.
+
+Going back to Oslo always feels like heading to another home, even more so now that Oslo's new trams are the same as Canberra's.
+
+![Oslo trams]({% link assets/blog/2024/2024-NIME-trip-17-oslo-trams.jpg %})
+
+Among many meetings with colleagues and new students I was able to repeat my AI NIME workshop with students from the Musicology Department (and give a little concert for them) as well as present my recent research on Intelligent Musical Instruments to the ROBIN group.
+
+![Oslo performance]({% link assets/blog/2024/2024-NIME-trip-15-oslo-performance.jpg %})
+
+![Oslo performance]({% link assets/blog/2024/2024-NIME-trip-16-oslo-performance.jpg %})
+
+![RITMO visit]({% link assets/blog/2024/2024-NIME-trip-19-oslo-ritmo.jpg %})
+
+![Seminar at Oslo]({% link assets/blog/2024/2024-NIME-trip-20-oslo-charles-seminar.jpg %})
+
+![Oslo snacks]({% link assets/blog/2024/2024-NIME-trip-18-oslo-snacks.jpg %})
+
+![Oslo]({% link assets/blog/2024/2024-NIME-trip-21-oslo.jpg %})


### PR DESCRIPTION
Converts the draft from _drafts/2024-NIME-draft.md into a published
blog post with 21 photos from the NIME trip assets folder, covering the
embedded AI workshop with Teresa Pelinski, Yichen and Sandy's Unspoken
performance, the NIME2025 Canberra announcement, and the Oslo visit to
ROBIN and RITMO colleagues.

https://claude.ai/code/session_01WzUMY4LUBEWd7ey4mRdUch